### PR TITLE
AGraph/Closeness/Betweenness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ keywords = ["p2p", "peer-to-peer", "networking"]
 
 [dependencies]
 nalgebra = "0.31"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,7 @@ keywords = ["p2p", "peer-to-peer", "networking"]
 
 [dependencies]
 nalgebra = "0.31"
+
+[dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     hash::Hash,
-    ops::Sub
+    ops::Sub,
 };
 
 use nalgebra::{DMatrix, DVector, SymmetricEigen};
@@ -12,7 +12,6 @@ use crate::edge::Edge;
 
 pub type Vertex = Vec<usize>;
 pub type AGraph = Vec<Vec<usize>>;
-
 
 /// An undirected graph, made up of edges.
 #[derive(Clone, Debug)]
@@ -32,7 +31,6 @@ pub struct Graph<T> {
     /// Cache the laplacian matrix when possible.
     laplacian_matrix: Option<DMatrix<f64>>,
 }
-
 
 impl<T> Default for Graph<T>
 where
@@ -490,25 +488,23 @@ where
             let source = *edge.source();
             let target = *edge.target();
 
-            let src_result = addresses.iter().position(|&r| r == source);
-            if src_result == None {
+            let source_result = addresses.iter().position(|&r| r == source);
+            if source_result.is_none() {
                 continue;
             }
 
-            let tgt_result = addresses.iter().position(|&r| r == target);
-            if tgt_result == None {
+            let target_result = addresses.iter().position(|&r| r == target);
+            if target_result.is_none() {
                 continue;
             }
 
-            let src_index = src_result.unwrap();
-            let tgt_index = tgt_result.unwrap();
-            agraph[src_index].push(tgt_index);
-            agraph[tgt_index].push(src_index);
+            let source_index = source_result.unwrap();
+            let target_index = target_result.unwrap();
+            agraph[source_index].push(target_index);
+            agraph[target_index].push(source_index);
         }
         agraph
-
     }
-
 
     // This method returns the closeness and betweenness for a given AGraph.
     //
@@ -526,24 +522,24 @@ where
     //      for all nodes in-between (i.e., not an end point)
     //        increment their betweenness value
     //
-    pub fn compute_betweenness_and_closeness (&self, agraph: &AGraph) ->  (Vec<u32>, Vec<f64>) {
+    pub fn compute_betweenness_and_closeness(&self, agraph: &AGraph) -> (Vec<u32>, Vec<f64>) {
         let num_nodes = agraph.len();
 
-        let mut betweenness: Vec<u32> = vec!(0; num_nodes);
-        let mut closeness: Vec<f64> = vec!(0.0; num_nodes);
-        let mut total_path_length: Vec<u32> = vec!(0; num_nodes);
-        let mut num_paths: Vec<u32> = vec!(0; num_nodes);
+        let mut betweenness: Vec<u32> = vec![0; num_nodes];
+        let mut closeness: Vec<f64> = vec![0.0; num_nodes];
+        let mut total_path_length: Vec<u32> = vec![0; num_nodes];
+        let mut num_paths: Vec<u32> = vec![0; num_nodes];
 
-        for i in 0..num_nodes-1 {
-            let mut visited: Vec<bool> = vec!(false; num_nodes);
-            let mut found_or_not: Vec<bool> = vec!(false; num_nodes);
+        for i in 0..num_nodes - 1 {
+            let mut visited: Vec<bool> = vec![false; num_nodes];
+            let mut found_or_not: Vec<bool> = vec![false; num_nodes];
             let mut search_list: Vec<usize> = Vec::new();
 
             // mark node i and all those before i as visited
-            for j in 0..i+1 {
+            for j in 0..i + 1 {
                 found_or_not[j] = true;
             }
-            for j in i+1..num_nodes {
+            for j in i + 1..num_nodes {
                 search_list.push(j);
                 found_or_not[j] = false;
             }
@@ -617,9 +613,7 @@ where
         }
 
         (betweenness, closeness)
-
     }
-
 }
 
 //
@@ -663,17 +657,14 @@ fn sorted_eigenvalue_vector_pairs(
 #[cfg(test)]
 mod tests {
     use nalgebra::dmatrix;
-    use std:: {
-        time::Instant,
-        fs
-    };
     use serde::Deserialize;
+    use std::{fs, time::Instant};
 
     use super::*;
 
     #[derive(Default, Clone, Deserialize)]
     pub struct AGraphSample {
-       pub agraph: AGraph
+        pub agraph: AGraph,
     }
 
     #[test]
@@ -1274,7 +1265,6 @@ mod tests {
         assert_eq!(closeness, expected_closeness);
     }
 
-
     // Helper function to create an AGraph from a json file.
     // The file will begin like this:
     //   {"agraph":[[2630,3217,1608,1035,...
@@ -1300,5 +1290,4 @@ mod tests {
         assert_eq!(agraph.len(), betweenness.len());
         assert_eq!(agraph.len(), closeness.len());
     }
-
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -516,12 +516,13 @@ where
     ///       find all shortest paths to that other node
     ///         accumlate all path lens
     ///         accumulate number of paths.
-    ///   compute average path length
+    ///     compute average path length
     ///
     ///  Betweenness:
     ///    When a shortest path is found
     ///      for all nodes in-between (i.e., not an end point)
     ///        increment their betweenness value
+    ///    Normalize the counts by dividing by the number of shortest paths found
     ///
     pub fn compute_betweenness_and_closeness(&self, agraph: &AGraph) -> (Vec<f64>, Vec<f64>) {
         let num_nodes = agraph.len();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -682,9 +682,10 @@ fn sorted_eigenvalue_vector_pairs(
 
 #[cfg(test)]
 mod tests {
+    use std::{fs, time::Instant};
+
     use nalgebra::dmatrix;
     use serde::Deserialize;
-    use std::{fs, time::Instant};
 
     use super::*;
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -68,6 +68,10 @@ where
         }
     }
 
+    pub fn edges(&mut self) -> &HashSet<Edge<T>> {
+        &self.edges
+    }
+
     /// Inserts an edge into the graph.
     pub fn insert(&mut self, edge: Edge<T>) -> bool {
         let is_inserted = self.edges.insert(edge);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -470,12 +470,15 @@ where
         self.index = Some(index);
     }
 
-    // creates an AGraph from a list of 'good' addresses and
-    // the Edges array.
-    // For each edge, if both nodes are in the good list,
-    // a connection is created for each node.
-    // The AGraph has a equivalent information as the edges,
-    // but is just a node-centric view (required for closeness)
+    /// Creates an AGraph from a list of addresses (which may
+    /// be filtered) and the edges array.
+    ///
+    /// For each edge, if both nodes are in the address list,
+    /// a connection is created for each node.
+    ///
+    /// The AGraph is a node-centric view (required for closeness)
+    /// of the same information in the edges, while also possibly
+    /// handling only a subset of all nodes.
     pub fn create_agraph(&self, addresses: &Vec<T>) -> AGraph {
         let num_nodes = addresses.len();
         let mut agraph: AGraph = AGraph::new();
@@ -510,19 +513,13 @@ where
 
     /// This method returns the closeness and betweenness for a given AGraph.
     ///
-    /// Closeness:
-    ///   for each node
-    ///     for all other nodes
-    ///       find all shortest paths to that other node
-    ///         accumlate all path lens
-    ///         accumulate number of paths.
-    ///     compute average path length
+    /// Closeness: for each node, find all shortest paths to all other nodes.
+    /// Accumulate all path lengths, accumulate number of paths, and then compute
+    /// average path length.
     ///
-    ///  Betweenness:
-    ///    When a shortest path is found
-    ///      for all nodes in-between (i.e., not an end point)
-    ///        increment their betweenness value
-    ///    Normalize the counts by dividing by the number of shortest paths found
+    /// Betweenness: When a shortest path is found, for all nodes
+    /// in-between (i.e., not an end point), increment their betweenness value.
+    /// Normalize the counts by dividing by the number of shortest paths found
     ///
     pub fn compute_betweenness_and_closeness(&self, agraph: &AGraph) -> (Vec<f64>, Vec<f64>) {
         let num_nodes = agraph.len();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3,10 +3,8 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     hash::Hash,
-    ops::Sub,
-    fs
+    ops::Sub
 };
-use serde::Deserialize;
 
 use nalgebra::{DMatrix, DVector, SymmetricEigen};
 
@@ -14,12 +12,6 @@ use crate::edge::Edge;
 
 pub type Vertex = Vec<usize>;
 pub type AGraph = Vec<Vec<usize>>;
-
-#[derive(Default, Clone, Deserialize)]
-pub struct AGraphSample {
-    pub agraph: AGraph
-}
-
 
 
 /// An undirected graph, made up of edges.
@@ -513,17 +505,6 @@ where
 
     }
 
-    // Create an AGraph from a json file.
-    // It will begin like this:
-    //   {"agraph":[[2630,3217,1608,1035,...
-    // and end like this:
-    //   ...2316,1068,1238,704,2013]]}
-    pub fn load_agraph(&self, crawler_report_path: &str) -> AGraph {
-        let jstring = fs::read_to_string(crawler_report_path).unwrap();
-        let agraph_sample: AGraphSample = serde_json::from_str(&jstring).unwrap();
-        let agraph = agraph_sample.agraph;
-        agraph
-    }
 
     // This method returns the closeness and betweenness for a given AGraph.
     //
@@ -678,9 +659,18 @@ fn sorted_eigenvalue_vector_pairs(
 #[cfg(test)]
 mod tests {
     use nalgebra::dmatrix;
-    use std::time::Instant;
+    use std:: {
+        time::Instant,
+        fs
+    };
+    use serde::Deserialize;
 
     use super::*;
+
+    #[derive(Default, Clone, Deserialize)]
+    pub struct AGraphSample {
+       pub agraph: AGraph
+    }
 
     #[test]
     fn new() {
@@ -1280,10 +1270,22 @@ mod tests {
         assert_eq!(closeness, expected_closeness);
     }
 
+
+    // Helper function to create an AGraph from a json file.
+    // The file will begin like this:
+    //   {"agraph":[[2630,3217,1608,1035,...
+    // and end like this:
+    //   ...2316,1068,1238,704,2013]]}
+    pub fn load_agraph(filepath: &str) -> AGraph {
+        let jstring = fs::read_to_string(filepath).unwrap();
+        let agraph_sample: AGraphSample = serde_json::from_str(&jstring).unwrap();
+        let agraph = agraph_sample.agraph;
+        agraph
+    }
+
     #[test]
     fn imported_sample_3226() {
-        let graph: Graph<usize> = Graph::new();
-        let agraph = graph.load_agraph("testdata/agraph-3226.json");
+        let agraph = load_agraph("testdata/agraph-3226.json");
         assert_eq!(agraph.len(), 3226);
         let graph: Graph<usize> = Graph::new();
         let start = Instant::now();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -474,6 +474,12 @@ where
         self.index = Some(index);
     }
 
+    // creates an AGraph from a list of 'good' addresses and
+    // the Edges array.
+    // For each edge, if both nodes are in the good list,
+    // a connection is created for each node.
+    // The AGraph has a equivalent information as the edges,
+    // but is just a node-centric view (required for closeness)
     pub fn create_agraph(&self, addresses: &Vec<T>) -> AGraph {
         let num_nodes = addresses.len();
         let mut agraph: AGraph = AGraph::new();
@@ -507,6 +513,11 @@ where
 
     }
 
+    // Create an AGraph from a json file.
+    // It will begin like this:
+    //   {"agraph":[[2630,3217,1608,1035,...
+    // and end like this:
+    //   ...2316,1068,1238,704,2013]]}
     pub fn load_agraph(&self, crawler_report_path: &str) -> AGraph {
         let jstring = fs::read_to_string(crawler_report_path).unwrap();
         let agraph_sample: AGraphSample = serde_json::from_str(&jstring).unwrap();
@@ -514,6 +525,22 @@ where
         agraph
     }
 
+    // This method returns the closeness and betweenness for a given AGraph.
+    //
+    // Closeness:
+    //   for each node
+    //     for all other nodes
+    //       find all shortest paths to that other node
+    //         accumlate all path lens
+    //         accumulate number of paths.
+    //   compute average path length
+    //
+    //
+    //  Betweenness:
+    //    When a shortest path is found
+    //      for all nodes in-between (i.e., not an end point)
+    //        increment their betweenness value
+    //
     pub fn compute_betweenness_and_closeness (&self, agraph: &AGraph) ->  (Vec<u32>, Vec<f64>) {
         let num_nodes = agraph.len();
 
@@ -1157,7 +1184,7 @@ mod tests {
 
         let total_path_length = [28, 11, 13, 14, 19, 14, 19];
         let num_paths = [10, 7, 7, 7, 7, 7, 7];
-        let mut expected_closeness: [f64; 7] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let mut expected_closeness: [f64; 7] = [0.0; 7];
         for i in 0..7 {
             expected_closeness[i] = total_path_length[i] as f64 / num_paths[i] as f64;
         }
@@ -1184,7 +1211,7 @@ mod tests {
 
         let total_path_length = [7, 13, 13, 13, 13, 13, 13, 13];
         let num_paths = [7, 7, 7, 7, 7, 7, 7, 7];
-        let mut expected_closeness: [f64; 8] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let mut expected_closeness: [f64; 8] = [0.0; 8];
         for i in 0..8 {
             expected_closeness[i] = total_path_length[i] as f64 / num_paths[i] as f64;
         }
@@ -1212,7 +1239,7 @@ mod tests {
 
         let total_path_length = [13, 13, 13, 13, 13, 13, 13, 7];
         let num_paths = [7, 7, 7, 7, 7, 7, 7, 7];
-        let mut expected_closeness: [f64; 8] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let mut expected_closeness: [f64; 8] = [0.0; 8];
         for i in 0..8 {
             expected_closeness[i] = total_path_length[i] as f64 / num_paths[i] as f64;
         }
@@ -1245,7 +1272,7 @@ mod tests {
 
         let total_path_length = [3, 3, 3, 3, 4, 7, 7, 7, 7];
         let num_paths = [3, 3, 3, 3, 4, 4, 4, 4, 4];
-        let mut expected_closeness: [f64; 9] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let mut expected_closeness: [f64; 9] = [0.0; 9];
         for i in 0..9 {
             expected_closeness[i] = total_path_length[i] as f64 / num_paths[i] as f64;
         }
@@ -1256,7 +1283,7 @@ mod tests {
     #[test]
     fn imported_sample_3226() {
         let graph: Graph<usize> = Graph::new();
-        let agraph = graph.load_agraph("testdata/agraph-3226.txt");
+        let agraph = graph.load_agraph("testdata/agraph-3226.json");
         assert_eq!(agraph.len(), 3226);
         let graph: Graph<usize> = Graph::new();
         let start = Instant::now();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -4,11 +4,23 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     hash::Hash,
     ops::Sub,
+    fs
 };
+use serde::Deserialize;
 
 use nalgebra::{DMatrix, DVector, SymmetricEigen};
 
 use crate::edge::Edge;
+
+pub type Vertex = Vec<usize>;
+pub type AGraph = Vec<Vec<usize>>;
+
+#[derive(Default, Clone, Deserialize)]
+pub struct AGraphSample {
+    pub agraph: AGraph
+}
+
+
 
 /// An undirected graph, made up of edges.
 #[derive(Clone, Debug)]
@@ -28,6 +40,7 @@ pub struct Graph<T> {
     /// Cache the laplacian matrix when possible.
     laplacian_matrix: Option<DMatrix<f64>>,
 }
+
 
 impl<T> Default for Graph<T>
 where
@@ -460,6 +473,141 @@ where
 
         self.index = Some(index);
     }
+
+    pub fn create_agraph(&self, addresses: &Vec<T>) -> AGraph {
+        let num_nodes = addresses.len();
+        let mut agraph: AGraph = AGraph::new();
+        for _ in 0..num_nodes {
+            agraph.push(Vertex::new());
+        }
+
+        // For all our edges, check if the nodes are in our address list
+        // We use the value of the addresses to find the index
+        // From then on, it's all integer indices for us
+        for edge in self.edges.iter() {
+            let source = *edge.source();
+            let target = *edge.target();
+
+            let src_result = addresses.iter().position(|&r| r == source);
+            if src_result == None {
+                continue;
+            }
+
+            let tgt_result = addresses.iter().position(|&r| r == target);
+            if tgt_result == None {
+                continue;
+            }
+
+            let src_index = src_result.unwrap();
+            let tgt_index = tgt_result.unwrap();
+            agraph[src_index].push(tgt_index);
+            agraph[tgt_index].push(src_index);
+        }
+        agraph
+
+    }
+
+    pub fn load_agraph(&self, crawler_report_path: &str) -> AGraph {
+        let jstring = fs::read_to_string(crawler_report_path).unwrap();
+        let agraph_sample: AGraphSample = serde_json::from_str(&jstring).unwrap();
+        let agraph = agraph_sample.agraph;
+        agraph
+    }
+
+    pub fn compute_betweenness_and_closeness (&self, agraph: &AGraph) ->  (Vec<u32>, Vec<f64>) {
+        let num_nodes = agraph.len();
+
+        let mut betweenness: Vec<u32> = vec!(0; num_nodes);
+        let mut closeness: Vec<f64> = vec!(0.0; num_nodes);
+        let mut total_path_length: Vec<u32> = vec!(0; num_nodes);
+        let mut num_paths: Vec<u32> = vec!(0; num_nodes);
+
+        for i in 0..num_nodes-1 {
+            let mut visited: Vec<bool> = vec!(false; num_nodes);
+            let mut found_or_not: Vec<bool> = vec!(false; num_nodes);
+            let mut search_list: Vec<usize> = Vec::new();
+
+            // mark node i and all those before i as visited
+            for j in 0..i+1 {
+                found_or_not[j] = true;
+            }
+            for j in i+1..num_nodes {
+                search_list.push(j);
+                found_or_not[j] = false;
+            }
+
+            while search_list.len() > 0 {
+                // 0. OUR MAIN SEARCH LOOP:  I and J
+                // 1. we search for path between i and j.  We're done when we find j
+                // 2. any short paths we find along the way, they get handled and removed from search list
+                // 3. along the way, we appropriately mark any between nodes
+                // 4. we also determine if no path exists (disconnected graph case)
+                let mut done = false;
+                let j = search_list[0];
+                for x in 0..num_nodes {
+                    visited[x] = x == i;
+                }
+                let mut pathlen: u32 = 1;
+                let mut queue_list = Vec::new();
+                queue_list.push(i);
+
+                while !done {
+                    let mut this_round_found: Vec<usize> = Vec::new();
+                    let mut queue_me = Vec::new();
+                    let mut touched: bool = false;
+                    for q in queue_list.as_slice() {
+                        let vertex = &agraph[*q];
+                        for x in vertex {
+                            // We collect all shortest paths for this length, as there may be multiple paths
+                            if !visited[*x] {
+                                touched = true;
+                                queue_me.push(*x);
+                                if !found_or_not[*x] {
+                                    this_round_found.push(*x);
+                                    if pathlen > 1 {
+                                        betweenness[*q] = betweenness[*q] + 1;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    queue_list.clear();
+                    for x in queue_me {
+                        queue_list.push(x);
+                        visited[x] = true;
+                    }
+                    for f in this_round_found {
+                        num_paths[f] = num_paths[f] + 1;
+                        total_path_length[f] = total_path_length[f] + pathlen;
+                        num_paths[i] = num_paths[i] + 1;
+                        total_path_length[i] = total_path_length[i] + pathlen;
+                        search_list.retain(|&x| x != f);
+                        found_or_not[f] = true;
+                        if f == j {
+                            done = true;
+                        }
+                    }
+                    // If no connection exists, stop searching for it.
+                    if !touched {
+                        search_list.retain(|&x| x != j);
+                        found_or_not[j] = true;
+                        done = true
+                    }
+
+                    pathlen = pathlen + 1;
+                }
+            }
+        }
+
+        for i in 0..num_nodes {
+            closeness[i] = total_path_length[i] as f64 / num_paths[i] as f64;
+        }
+
+        (betweenness, closeness)
+
+    }
+
 }
 
 //
@@ -503,6 +651,7 @@ fn sorted_eigenvalue_vector_pairs(
 #[cfg(test)]
 mod tests {
     use nalgebra::dmatrix;
+    use std::time::Instant;
 
     use super::*;
 
@@ -988,4 +1137,151 @@ mod tests {
 
         assert_eq!(graph.index.as_ref().unwrap().len(), 2);
     }
+
+    #[test]
+    fn randomish_graph() {
+        let (s0, s1, s2, s3, s4, s5, s6) = ("0", "1", "2", "3", "4", "5", "6");
+        let addresses = vec!["0", "1", "2", "3", "4", "5", "6"];
+        let mut graph: Graph<&str> = Graph::new();
+        // this graph reproduces the image at:
+        // https://www.sotr.blog/articles/breadth-first-search
+        graph.insert(Edge::new(s0, s3));
+        graph.insert(Edge::new(s0, s5));
+        graph.insert(Edge::new(s5, s1));
+        graph.insert(Edge::new(s1, s2));
+        graph.insert(Edge::new(s2, s4));
+        graph.insert(Edge::new(s2, s6));
+        graph.insert(Edge::new(s1, s3));
+        let agraph = graph.create_agraph(&addresses);
+        let (betweenness, closeness) = graph.compute_betweenness_and_closeness(&agraph);
+
+        let total_path_length = [28, 11, 13, 14, 19, 14, 19];
+        let num_paths = [10, 7, 7, 7, 7, 7, 7];
+        let mut expected_closeness: [f64; 7] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        for i in 0..7 {
+            expected_closeness[i] = total_path_length[i] as f64 / num_paths[i] as f64;
+        }
+        assert_eq!(betweenness, [1, 6, 10, 1, 0, 1, 0]);
+        assert_eq!(closeness, expected_closeness);
+    }
+
+    #[test]
+    fn star_graph_a() {
+        // 7-pointed star, 8 nodes
+        // center is 0
+        let (s0, s1, s2, s3, s4, s5, s6, s7) = ("0", "1", "2", "3", "4", "5", "6", "7");
+        let addresses = vec!["0", "1", "2", "3", "4", "5", "6", "7"];
+        let mut graph: Graph<&str> = Graph::new();
+        graph.insert(Edge::new(s0, s1));
+        graph.insert(Edge::new(s0, s2));
+        graph.insert(Edge::new(s0, s3));
+        graph.insert(Edge::new(s0, s4));
+        graph.insert(Edge::new(s0, s5));
+        graph.insert(Edge::new(s0, s6));
+        graph.insert(Edge::new(s0, s7));
+        let agraph = graph.create_agraph(&addresses);
+        let (betweenness, closeness) = graph.compute_betweenness_and_closeness(&agraph);
+
+        let total_path_length = [7, 13, 13, 13, 13, 13, 13, 13];
+        let num_paths = [7, 7, 7, 7, 7, 7, 7, 7];
+        let mut expected_closeness: [f64; 8] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        for i in 0..8 {
+            expected_closeness[i] = total_path_length[i] as f64 / num_paths[i] as f64;
+        }
+        assert_eq!(betweenness, [21, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(closeness, expected_closeness);
+    }
+
+    #[test]
+    fn star_graph_b() {
+        // 7-pointed star, 8 nodes
+        // center is 7
+        let (s0, s1, s2, s3, s4, s5, s6, s7) = ("0", "1", "2", "3", "4", "5", "6", "7");
+        let addresses = vec!["0", "1", "2", "3", "4", "5", "6", "7"];
+        let mut graph: Graph<&str> = Graph::new();
+        graph.insert(Edge::new(s0, s7));
+        graph.insert(Edge::new(s1, s7));
+        graph.insert(Edge::new(s2, s7));
+        graph.insert(Edge::new(s3, s7));
+        graph.insert(Edge::new(s4, s7));
+        graph.insert(Edge::new(s5, s7));
+        graph.insert(Edge::new(s6, s7));
+
+        let agraph = graph.create_agraph(&addresses);
+        let (betweenness, closeness) = graph.compute_betweenness_and_closeness(&agraph);
+
+        let total_path_length = [13, 13, 13, 13, 13, 13, 13, 7];
+        let num_paths = [7, 7, 7, 7, 7, 7, 7, 7];
+        let mut expected_closeness: [f64; 8] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        for i in 0..8 {
+            expected_closeness[i] = total_path_length[i] as f64 / num_paths[i] as f64;
+        }
+        assert_eq!(betweenness, [0, 0, 0, 0, 0, 0, 0, 21]);
+        assert_eq!(closeness, expected_closeness);
+    }
+
+    #[test]
+    fn disconnected_graph() {
+        // 9 vertices
+        // 4 verts, 0-3: square, all points connected
+        // 5 verts, 4-8: star, with v4 in the center
+        let (s0, s1, s2, s3, s4, s5, s6, s7, s8) = ("0", "1", "2", "3", "4", "5", "6", "7", "8");
+        let addresses = vec!["0", "1", "2", "3", "4", "5", "6", "7", "8"];
+        let mut graph: Graph<&str> = Graph::new();
+        graph.insert(Edge::new(s0, s1));
+        graph.insert(Edge::new(s0, s2));
+        graph.insert(Edge::new(s0, s3));
+        graph.insert(Edge::new(s1, s2));
+        graph.insert(Edge::new(s1, s3));
+        graph.insert(Edge::new(s2, s3));
+
+        graph.insert(Edge::new(s4, s5));
+        graph.insert(Edge::new(s4, s6));
+        graph.insert(Edge::new(s4, s7));
+        graph.insert(Edge::new(s4, s8));
+
+        let agraph = graph.create_agraph(&addresses);
+        let (betweenness, closeness) = graph.compute_betweenness_and_closeness(&agraph);
+
+        let total_path_length = [3, 3, 3, 3, 4, 7, 7, 7, 7];
+        let num_paths = [3, 3, 3, 3, 4, 4, 4, 4, 4];
+        let mut expected_closeness: [f64; 9] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        for i in 0..9 {
+            expected_closeness[i] = total_path_length[i] as f64 / num_paths[i] as f64;
+        }
+        assert_eq!(betweenness, [0, 0, 0, 0, 6, 0, 0, 0, 0]);
+        assert_eq!(closeness, expected_closeness);
+    }
+
+    #[test]
+    fn imported_sample_3226() {
+        let graph: Graph<usize> = Graph::new();
+        let agraph = graph.load_agraph("testdata/agraph-3226.txt");
+        assert_eq!(agraph.len(), 3226);
+        let graph: Graph<usize> = Graph::new();
+        let start = Instant::now();
+        let (betweenness, closeness) = graph.compute_betweenness_and_closeness(&agraph);
+        let elapsed = start.elapsed();
+        println!("elapsed for 3226 nodes: {:?}", elapsed);
+        assert!(elapsed.as_secs() < 45);
+        assert_eq!(agraph.len(), betweenness.len());
+        assert_eq!(agraph.len(), closeness.len());
+    }
+
+    #[test]
+    fn imported_sample_4914() {
+        let graph: Graph<usize> = Graph::new();
+        let agraph = graph.load_agraph("testdata/agraph-4914.txt");
+        assert_eq!(agraph.len(), 4914);
+        // this test lasts 10-11 minutes; for the time being, we skip it
+        // let graph: Graph<usize> = Graph::new();
+        // let start = Instant::now();
+        // let (betweenness, closeness) = graph.compute_betweenness_and_closeness(&agraph);
+        // let elapsed = start.elapsed();
+        // println!("elapsed for 4914 nodes: {:?}", elapsed);
+        // assert!(elapsed.as_secs() < 900);
+        // assert_eq!(agraph.len(), betweenness.len());
+        // assert_eq!(agraph.len(), closeness.len());
+    }
+
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1268,20 +1268,4 @@ mod tests {
         assert_eq!(agraph.len(), closeness.len());
     }
 
-    #[test]
-    fn imported_sample_4914() {
-        let graph: Graph<usize> = Graph::new();
-        let agraph = graph.load_agraph("testdata/agraph-4914.txt");
-        assert_eq!(agraph.len(), 4914);
-        // this test lasts 10-11 minutes; for the time being, we skip it
-        // let graph: Graph<usize> = Graph::new();
-        // let start = Instant::now();
-        // let (betweenness, closeness) = graph.compute_betweenness_and_closeness(&agraph);
-        // let elapsed = start.elapsed();
-        // println!("elapsed for 4914 nodes: {:?}", elapsed);
-        // assert!(elapsed.as_secs() < 900);
-        // assert_eq!(agraph.len(), betweenness.len());
-        // assert_eq!(agraph.len(), closeness.len());
-    }
-
 }


### PR DESCRIPTION
just a few notes:
- for the serialization, I rethought this, and am only importing the `agraph` field, not an entire crawler report.  We don't want spectre to have to know anything about that or NetworkSummary
- I edited the data files from the original reports.  Eventually, the crawler will export the agraph alone, or better, the extraction of the agraph from the crawler report will be done in the code that actually calls the closeness/betweenness computation
- I had some problem pushing a 14MB json file (for 4914 nodes), so for now, the test suite only imports the 3226-node graph (5.6 MB), which is good enough for now.